### PR TITLE
Add PyPI upload support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ black:
 build:
 	bin/create_version
 	docker build -t ${IMAGE_NAME} .
+
+upload:
+	twine upload --repository-url https://upload.pypi.org/legacy/ dist/*

--- a/README.md
+++ b/README.md
@@ -252,6 +252,17 @@ unfamiliar with:
 Feel free to reach out to the mentors by email or on Gitter if you have further
 questions or are having trouble getting set up!
 
+## Updating PyPI
+
+Use twine to upload a new version to PyPI.
+
+```bash
+python setup.py sdist
+twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+```
+
+There is a Makefile target `make upload` which will invoke twine for
+you.
 
 ## Resources
 

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
     - plotnine==0.6.0
     - pytest==5.4.3
     - pytest-cov==2.10.0
+    - twine==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,21 @@
 from setuptools import find_packages, setup
 
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name="PRESC",
     use_scm_version=False,
-    version="0.1.0",
+    version="0.1.1",
     setup_requires=["setuptools_scm", "pytest-runner"],
     tests_require=["pytest"],
     include_package_data=True,
     packages=find_packages(exclude=["archive", "tests", "tests/*"]),
     description="Performance Robustness Evaluation for Statistical Classifiers",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+
     author="Mozilla Corporation",
     author_email="mroviraesteva@mozilla.com",
     url="https://github.com/mozilla/presc",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     description="Performance Robustness Evaluation for Statistical Classifiers",
     long_description=long_description,
     long_description_content_type="text/markdown",
-
     author="Mozilla Corporation",
     author_email="mroviraesteva@mozilla.com",
     url="https://github.com/mozilla/presc",


### PR DESCRIPTION
* twine has been added as a dependency to support PyPI uploads
* `upload` target added to Makefile
* PyPI upload docs added to README
* setup.py modified to include a long_description for the PyPI index