### PR TITLE
Closes #263: Expands and implements config options

### DIFF
--- a/presc/config_default.yaml
+++ b/presc/config_default.yaml
@@ -1,0 +1,59 @@
+# Look and structure of the report
+report:
+  # Report title (passed to jupyter-book config)
+  title: PRESC report
+  # Report author (passed to jupyter-book config)
+  author: ""
+  # List of evaluations to show in the report. Each is added in a separate page.
+  # Values must correspond to module names for available evaluations.
+  # The report will include only those listed in `evaluations_include`,
+  # after removing any listed in `evaluations_exclude`.
+  # "*" means 'all available evaluations'.
+  evaluations_include: "*"
+  evaluations_exclude: null
+
+# Computation options for individual evaluations
+evaluations:
+  conditional_metric:
+    # Dataset columns to run the evaluation for.
+    # Follows the same logic as for report evaluations.
+    # "*" means 'all feature and other columns'.
+    # Results will be ordered according to `columns_include`.
+    columns_include: "*"
+    columns_exclude: null
+    computation:
+      # Number of bins for partitioning a numeric column
+      num_bins: 10
+      # Should bin widths correspond to quantiles of a numerical column's
+      # distribution (True) or be equally-spaced over its range (False)
+      quantile: False
+      # Should the grouping column be treated as categorical, ie. binned on its
+      # unique values? Only applies if the column is numeric
+      as_categorical: False
+      # A dictionary of per-column overrides for the computation options.
+      # Entries should have a column name as their key and settings for the
+      # options above as their value.
+      columns: null
+
+  conditional_distribution:
+    # Dataset columns to run the evaluation for.
+    # Follows the same logic as for report evaluations.
+    # "*" means 'all feature and other columns'.
+    columns_include: "*"
+    columns_exclude: null
+    computation:
+      # Binning scheme to use for a numerical column, passed to `numpy.histogram`.
+      # Can be a fixed number of bins or a string indicating a binning scheme
+      binning: fd
+      # Should the bins be computed over the entire column and shared across
+      # groups (True) or computed within each group (False)
+      common_bins: True
+      # Should the data column be treated as categorical, ie. binned on its
+      # unique values? Only applies if the column is numeric
+      as_categorical: False
+      # A dictionary of per-column overrides for the computation options.
+      # Entries should have a column name as their key and settings for the
+      # options above as their value.
+      columns: null
+
+

--- a/presc/dataset.py
+++ b/presc/dataset.py
@@ -49,6 +49,12 @@ class Dataset:
         return self._df[other_cols]
 
     @property
+    def column_names(self):
+        """Returns feature and other column names."""
+        other_colnames = list(self.other_cols.columns)
+        return self.feature_names + other_colnames
+
+    @property
     def df(self):
         """Returns the underlying DataFrame."""
         return self._df

--- a/presc/evaluations/conditional_metric.py
+++ b/presc/evaluations/conditional_metric.py
@@ -1,4 +1,5 @@
 from presc.evaluations.utils import get_bins, is_discrete
+from presc.utils import include_exclude_list
 
 from pandas import DataFrame, Series
 from sklearn.metrics import accuracy_score
@@ -9,7 +10,13 @@ METRIC = accuracy_score
 
 
 def compute_conditional_metric(
-    grouping_col, true_labs, pred_labs, metric, as_categorical=False, config=None
+    grouping_col,
+    true_labs,
+    pred_labs,
+    metric,
+    as_categorical=False,
+    num_bins=10,
+    quantile=False,
 ):
     """Compute metric values conditional on the grouping column.
 
@@ -24,7 +31,9 @@ def compute_conditional_metric(
         predicted labels.
     as_categorical: should the grouping column be treated as categorical, ie. binned
         on its unique values? If it is not numeric, this param is ignored.
-    config: dict of config options
+    num_bins: number of bins to use for grouping a numeric column
+    quantile: should the bin widths correpond to quantiles of a numerical column's
+        distribution (`True`) or be equally-spaced over its range (`False`)
 
     Returns a `ConditionalMetricResult` instance.
     """
@@ -36,11 +45,7 @@ def compute_conditional_metric(
         grouping = grouping_col
         bins = grouping.unique()
     else:
-        grouping, bins = get_bins(
-            grouping_col,
-            num_bins=config["num_bins"],
-            quantile=config["quantile"],
-        )
+        grouping, bins = get_bins(grouping_col, num_bins, quantile)
     binned_metric_vals = y_vals.groupby(grouping).apply(
         lambda gp: metric(gp["y_true"], gp["y_pred"])
     )
@@ -49,7 +54,8 @@ def compute_conditional_metric(
         vals=binned_metric_vals,
         bins=Series(bins),
         categorical=as_categorical,
-        config=config,
+        num_bins=num_bins,
+        quantile=quantile,
     )
 
 
@@ -61,14 +67,16 @@ class ConditionalMetricResult:
         numeric, this will have length `len(vals)+1`, otherwise `len(vals)`.
     categorical: was the feature treated as categorical?
     config: dict of config options
-
+    num_bins: number of bins used for grouping
+    quantile: was grouping quantile-based?
     """
 
-    def __init__(self, vals, bins, categorical, config=None):
+    def __init__(self, vals, bins, categorical, num_bins, quantile):
         self.vals = vals
         self.bins = bins
         self.categorical = categorical
-        self.config = config
+        self.num_bins = num_bins
+        self.quantile = quantile
 
     def display_result(self, xlab, ylab):
         """Display the evaluation result for the given grouping and metric.
@@ -81,13 +89,13 @@ class ConditionalMetricResult:
         if self.categorical:
             result_edges = self.bins.astype("str")
             alignment = "center"
-            width_interval = 1
+            # width_interval = 1
         else:
             result_edges = self.bins[:-1]
             alignment = "edge"
             # First element will be NaN.
             bin_widths = self.bins.diff()[1:]
-            width_interval = bin_widths * self.config["plot_width_fraction"]
+            # width_interval = bin_widths * self.config["plot_width_fraction"]
 
         plt.ylim(0, 1)
         plt.xlabel(xlab)
@@ -95,7 +103,8 @@ class ConditionalMetricResult:
         plt.bar(
             result_edges,
             self.vals,
-            width=width_interval,
+            # width=width_interval,
+            width=bin_widths,
             bottom=None,
             align=alignment,
             edgecolor="white",
@@ -109,21 +118,16 @@ class ConditionalMetric:
 
     model: the ClassificationModel to run the evaluation for
     test_dataset: a Dataset to use for evaluation.
-    config: dict of config options. Available options:
-        `num_bins`: number of bins to use for grouping a numerical column, default: 10
-        `quantile`: should the bin widths correpond to quantiles of a numerical column's
-            distribution (`True`) or be equally-spaced over its range (`False`), default: False
-        `plot_width_fraction`: width of the bars relative to available space on the plot.
-            Smaller means more space between the bars, default: 1.0
+    config: the main config dict
     """
 
-    def __init__(self, model, test_dataset, config=None):
-        self._config = config
+    def __init__(self, model, test_dataset, config):
+        self._config = config["evaluations"]["conditional_metric"]
         self._model = model
         self._test_dataset = test_dataset
         self._test_pred = self._model.predict_labels(test_dataset)
 
-    def compute_for_column(self, colname, metric, as_categorical=False):
+    def compute_for_column(self, colname, metric, **kwargs):
         """Compute the evaluation for the given dataset column.
 
         The metric is computed within unique values of the specified column
@@ -133,31 +137,45 @@ class ConditionalMetric:
         metric: the evaluation metric to compute across the partitions. This should be
             a function f(y_true, y_pred) which accepts Series of true and
             predicted labels.
-        as_categorical: should the feature be treated as categorical, ie. binned
-            on its unique values? If the feature is not numeric, this param is
-            ignored.
+        kwargs: overrides to the default option values for the computation.
 
         Returns a `ConditionalMetricResult` instance.
         """
+        comp_config = dict(self._config["computation"])
+        col_overrides = comp_config.pop("columns", {})
+        if col_overrides:
+            comp_config.update(col_overrides.get(colname, {}))
+        comp_config.update(kwargs)
+
         return compute_conditional_metric(
             grouping_col=self._test_dataset.df[colname],
             true_labs=self._test_dataset.labels,
             pred_labs=self._test_pred,
             metric=metric,
-            as_categorical=as_categorical,
-            config=self._config,
+            as_categorical=comp_config["as_categorical"],
+            num_bins=comp_config["num_bins"],
+            quantile=comp_config["quantile"],
         )
 
     def display(self, colnames=None, metric_name="Metric value"):
         """Computes and displays the conditional metric result for each specified column.
 
         colnames: a list of column names to run the evaluation over, creating a plot
-            for each. If not supplied, defaults to all feature columns.
+            for each. If not supplied, defaults to columns specifed in the
+            config.
         metric_name: display name identifying the metric to show on the plot
         """
-        if colnames is None:
-            colnames = self._test_dataset.feature_names
-        for colname in colnames:
+        if colnames:
+            incl = colnames
+            excl = None
+        else:
+            incl = self._config["columns_include"]
+            excl = self._config["columns_exclude"]
+        cols = include_exclude_list(
+            self._test_dataset.column_names, included=incl, excluded=excl
+        )
+
+        for colname in cols:
             # TODO: don't hardcode the metric
             eval_result = self.compute_for_column(colname, metric=METRIC)
             eval_result.display_result(xlab=colname, ylab=metric_name)

--- a/presc/evaluations/conditional_metric.py
+++ b/presc/evaluations/conditional_metric.py
@@ -66,7 +66,6 @@ class ConditionalMetricResult:
     bins: a Series listing the bin endpoints. If the feature was treated as
         numeric, this will have length `len(vals)+1`, otherwise `len(vals)`.
     categorical: was the feature treated as categorical?
-    config: dict of config options
     num_bins: number of bins used for grouping
     quantile: was grouping quantile-based?
     """
@@ -89,13 +88,12 @@ class ConditionalMetricResult:
         if self.categorical:
             result_edges = self.bins.astype("str")
             alignment = "center"
-            # width_interval = 1
+            widths = 1
         else:
             result_edges = self.bins[:-1]
             alignment = "edge"
             # First element will be NaN.
-            bin_widths = self.bins.diff()[1:]
-            # width_interval = bin_widths * self.config["plot_width_fraction"]
+            widths = self.bins.diff()[1:]
 
         plt.ylim(0, 1)
         plt.xlabel(xlab)
@@ -103,8 +101,7 @@ class ConditionalMetricResult:
         plt.bar(
             result_edges,
             self.vals,
-            # width=width_interval,
-            width=bin_widths,
+            width=widths,
             bottom=None,
             align=alignment,
             edgecolor="white",
@@ -161,8 +158,7 @@ class ConditionalMetric:
         """Computes and displays the conditional metric result for each specified column.
 
         colnames: a list of column names to run the evaluation over, creating a plot
-            for each. If not supplied, defaults to columns specifed in the
-            config.
+            for each. If not supplied, defaults to columns specifed in the config.
         metric_name: display name identifying the metric to show on the plot
         """
         if colnames:

--- a/presc/report/default_config.yml
+++ b/presc/report/default_config.yml
@@ -1,9 +1,0 @@
-conditional_metric:
-  num_bins: 20
-  quantile: False
-  plot_width_fraction: 1.0
-
-conditional_distribution:
-  binning: fd
-  common_bins: True
-  plot_width_fraction: 1.0

--- a/presc/report/resources/conditional_distribution.ipynb
+++ b/presc/report/resources/conditional_distribution.ipynb
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "e = ConditionalDistribution(cm, test_dataset, config=config.get(\"conditional_distribution\"))"
+    "e = ConditionalDistribution(cm, test_dataset, config=config)"
    ]
   },
   {

--- a/presc/report/resources/conditional_metric.ipynb
+++ b/presc/report/resources/conditional_metric.ipynb
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "e = ConditionalMetric(cm, test_dataset, config=config.get(\"conditional_metric\"))"
+    "e = ConditionalMetric(cm, test_dataset, config=config)"
    ]
   },
   {

--- a/presc/report/runner.py
+++ b/presc/report/runner.py
@@ -22,7 +22,7 @@ JB_BUILD_LOG = "jupyterbook_build.log"
 # for the report.
 CONTEXT_STORE_BASENAME = "_context_store"
 # Path to the default config file
-DEFAULT_CONFIG_PATH = Path(__file__).parent / "default_config.yml"
+DEFAULT_CONFIG_PATH = Path(__file__).parent.parent / "config_default.yaml"
 
 
 def load_config(config_filepath=None):

--- a/presc/report/runner.py
+++ b/presc/report/runner.py
@@ -8,10 +8,12 @@ import webbrowser
 
 import yaml
 
-from presc.utils import PrescError
+from presc.utils import PrescError, include_exclude_list
 
 # Path to the report source dir
 REPORT_SOURCE_PATH = Path(__file__).parent / "resources"
+JB_CONFIG_FILENAME = "_config.yml"
+JB_TOC_FILENAME = "_toc.yml"
 REPORT_OUTPUT_DIR = "presc_report"
 REPORT_EXECUTION_DIR = "_exec"
 REPORT_MAIN_PAGE = "report.html"
@@ -44,6 +46,59 @@ def load_config(config_filepath=None):
     except yaml.YAMLError as e:
         msg = f"Error parsing config file {config_filepath}"
         raise PrescError(msg) from e
+
+
+def _updated_jb_config(report_config):
+    """Override default jupyter-book options.
+
+    report_config: PRESC config options for the report
+
+    Returns the updated JB config file as a YAML-formatted string that can be
+    written to a _config.yml.
+    """
+    with open(REPORT_SOURCE_PATH / JB_CONFIG_FILENAME) as f:
+        jb_config = yaml.load(f, Loader=yaml.FullLoader)
+
+    jb_config["title"] = report_config["title"]
+    jb_config["author"] = report_config["author"]
+    return yaml.dump(jb_config)
+
+
+def _updated_jb_toc(report_config):
+    """Override default report TOC.
+
+    This does not change the sections or the order of the pages but only which
+    pages are included.
+
+    report_config: PRESC config options for the report
+
+    Returns the updated JB TOC file as a YAML-formatted string that can be
+    written to a _toc.yml.
+    """
+    # Rather than parsing as YAML and dealing with the nested structure,
+    # just look through the raw lines of the file for report page entries
+    # starting with "- file: "
+    with open(REPORT_SOURCE_PATH / JB_TOC_FILENAME) as f:
+        toc_lines = f.readlines()
+
+    stripped_lines = [(i, x.strip()) for i, x in enumerate(toc_lines)]
+    all_pages = {i: x[8:] for i, x in stripped_lines if x.startswith("- file: ")}
+    incl_pages = include_exclude_list(
+        list(all_pages.values()),
+        report_config["evaluations_include"],
+        report_config["evaluations_exclude"],
+    )
+    # Landing page should always be included.
+    if "landing" not in incl_pages:
+        incl_pages.append("landing")
+
+    # Retain all TOC lines except those corresponding to excluded pages.
+    filtered_toc = [
+        x
+        for i, x in enumerate(toc_lines)
+        if i not in all_pages or all_pages[i] in incl_pages
+    ]
+    return "".join(filtered_toc)
 
 
 class ReportRunner:
@@ -149,6 +204,13 @@ class ReportRunner:
         except shutil.Error as e:
             msg = f"Failed to copy report source to execution dir {exec_path}"
             raise PrescError(msg) from e
+
+        # Update the default JB config files based on the PRESC config options.
+        with open(exec_path / JB_CONFIG_FILENAME, "w") as f:
+            f.write(_updated_jb_config(config["report"]))
+        with open(exec_path / JB_TOC_FILENAME, "w") as f:
+            f.write(_updated_jb_toc(config["report"]))
+
         # Write the inputs to the data store.
         ctx = Context(store_dir=exec_path)
         ctx.store_inputs(model=model, test_dataset=test_dataset, config=config)

--- a/presc/utils.py
+++ b/presc/utils.py
@@ -14,6 +14,8 @@ def include_exclude_list(all_vals, included="*", excluded=None):
 
     The special values "*" and None are interpreted as "all" and "none"
     respectively for `included` and `excluded`.
+
+    Returns the list of values out of `all_vals` that should be included.
     """
     if not included or excluded == "*":
         return []

--- a/presc/utils.py
+++ b/presc/utils.py
@@ -1,2 +1,29 @@
 class PrescError(ValueError, AttributeError):
     """General exception class for errors related to PRESC computations."""
+
+
+def include_exclude_list(all_vals, included="*", excluded=None):
+    """Find values remaining after inclusions and exclusions are applied.
+
+    Values are first restricted to explicit inclusions, and then exclusions are
+    applied.
+
+    all_vals: the full list of possible values
+    included: the list of values to include. Those not listed here are dropped.
+    excluded: the list of values to drop (after restricting to included).
+
+    The special values "*" and None are interpreted as "all" and "none"
+    respectively for `included` and `excluded`.
+    """
+    if not included or excluded == "*":
+        return []
+
+    if included == "*":
+        incl_vals = all_vals
+    else:
+        incl_vals = [x for x in included if x in all_vals]
+
+    if excluded:
+        incl_vals = [x for x in incl_vals if x not in excluded]
+
+    return incl_vals

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from numpy import arange
 
 from presc.model import ClassificationModel
 from presc.dataset import Dataset
+from presc.report.runner import load_config
 
 DATASET_DF_PATH = Path(__file__).parent / "fixtures" / "dataset.pkl"
 
@@ -56,3 +57,8 @@ def pipeline_classifier(dataset_transform):
 @pytest.fixture
 def classification_model(pipeline_classifier, train_dataset):
     return ClassificationModel(pipeline_classifier, train_dataset, retrain_now=True)
+
+
+@pytest.fixture
+def config_default():
+    return load_config()

--- a/tests/fixtures/config_test_report.yaml
+++ b/tests/fixtures/config_test_report.yaml
@@ -1,0 +1,30 @@
+report:
+  title: PRESC report
+  author: ""
+  evaluations_include: "*"
+  evaluations_exclude: null
+
+evaluations:
+  conditional_metric:
+    columns_include:
+      - a
+      - c
+    columns_exclude: null
+    computation:
+      num_bins: 3
+      quantile: False
+      as_categorical: False
+      columns: null
+
+  conditional_distribution:
+    columns_include:
+      - a
+      - c
+    columns_exclude: null
+    computation:
+      binning: fd
+      common_bins: True
+      as_categorical: False
+      columns: null
+
+

--- a/tests/test_conditional_distribution.py
+++ b/tests/test_conditional_distribution.py
@@ -1,0 +1,122 @@
+from copy import deepcopy
+
+import pytest
+import yaml
+from numpy.testing import assert_array_equal
+from pandas import MultiIndex
+
+from presc.evaluations.conditional_distribution import (
+    ConditionalDistribution,
+    ConditionalDistributionResult,
+)
+
+
+COLUMN_OVERRIDE_YAML = """
+columns:
+  a:
+    common_bins: False
+"""
+
+COLNAME_LIST_YAML = """
+conditional_distribution:
+  columns_include:
+    - a
+    - c
+    - e
+"""
+
+
+@pytest.fixture
+def config_col_override(config_default):
+    conf = deepcopy(config_default)
+    extra = yaml.load(COLUMN_OVERRIDE_YAML, Loader=yaml.FullLoader)
+    conf["evaluations"]["conditional_distribution"]["computation"]["columns"] = extra[
+        "columns"
+    ]
+    return conf
+
+
+@pytest.fixture
+def config_colname(config_col_override):
+    conf = deepcopy(config_col_override)
+    extra = yaml.load(COLNAME_LIST_YAML, Loader=yaml.FullLoader)
+    conf["evaluations"]["conditional_distribution"]["columns_include"] = extra[
+        "conditional_distribution"
+    ]["columns_include"]
+    return conf
+
+
+@pytest.fixture
+def result_class_no_display(monkeypatch):
+    class CDRPatched(ConditionalDistributionResult):
+        def display_result(self, xlab):
+            print(f"{xlab}:{isinstance(self.bins.index, MultiIndex)}")
+
+    from presc.evaluations import conditional_distribution
+
+    monkeypatch.setattr(
+        conditional_distribution, "ConditionalDistributionResult", CDRPatched
+    )
+
+
+def test_eval_compute_for_column(
+    test_dataset, classification_model, config_default, config_col_override
+):
+    # Defaults
+    cde = ConditionalDistribution(classification_model, test_dataset, config_default)
+    cdr = cde.compute_for_column("a")
+    # Same number of bins in each group
+    assert_array_equal(cdr.vals.groupby(["label", "predicted"]).size().unique(), 3)
+    assert cdr.binning == "fd"
+    assert cdr.common_bins is True
+
+    # Column-specific override
+    cde = ConditionalDistribution(
+        classification_model, test_dataset, config_col_override
+    )
+    cdr_a = cde.compute_for_column("a")
+    assert cdr_a.vals.groupby(["label", "predicted"]).size().nunique() > 1
+    assert cdr_a.common_bins is False
+    cdr_b = cde.compute_for_column("b")
+    assert cdr_b.vals.groupby(["label", "predicted"]).size().nunique() == 1
+    assert cdr_b.common_bins is True
+
+    # kwarg override
+    cdr_a = cde.compute_for_column("a", binning=3, common_bins=False)
+    assert_array_equal(cdr_a.vals.groupby(["label", "predicted"]).size().unique(), 3)
+    # Bins are not all the same
+    assert isinstance(cdr_a.bins.index, MultiIndex)
+    assert cdr_a.binning == 3
+    assert cdr_a.common_bins is False
+    cdr_b = cde.compute_for_column("b", binning=3)
+    assert_array_equal(cdr_b.vals.groupby(["label", "predicted"]).size().unique(), 3)
+    assert not isinstance(cdr_b.bins.index, MultiIndex)
+    assert cdr_b.binning == 3
+    assert cdr_b.common_bins is True
+
+
+def test_eval_display(
+    test_dataset,
+    classification_model,
+    config_default,
+    config_colname,
+    result_class_no_display,
+    capsys,
+):
+    cde = ConditionalDistribution(classification_model, test_dataset, config_default)
+    cde.display()
+    cols_displayed = capsys.readouterr().out
+    assert len(cols_displayed.split()) == 5
+
+    cde.display(colnames=["a", "c"])
+    cols_displayed = capsys.readouterr().out
+    assert [x.strip() for x in cols_displayed.split()] == ["a:False", "c:False"]
+
+    cde = ConditionalDistribution(classification_model, test_dataset, config_colname)
+    cde.display()
+    cols_displayed = capsys.readouterr().out
+    assert [x.strip() for x in cols_displayed.split()] == [
+        "a:True",
+        "c:False",
+        "e:False",
+    ]

--- a/tests/test_conditional_metric.py
+++ b/tests/test_conditional_metric.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 import pytest
 import yaml
 
-from presc.report.runner import load_config
 from presc.evaluations.conditional_metric import (
     ConditionalMetric,
     METRIC,
@@ -24,11 +23,6 @@ conditional_metric:
     - c
     - e
 """
-
-
-@pytest.fixture
-def config_default():
-    return load_config()
 
 
 @pytest.fixture

--- a/tests/test_conditional_metric.py
+++ b/tests/test_conditional_metric.py
@@ -1,0 +1,113 @@
+from copy import deepcopy
+
+import pytest
+import yaml
+
+from presc.report.runner import load_config
+from presc.evaluations.conditional_metric import (
+    ConditionalMetric,
+    METRIC,
+    ConditionalMetricResult,
+)
+
+
+COLUMN_OVERRIDE_YAML = """
+columns:
+  a:
+    num_bins: 5
+"""
+
+COLNAME_LIST_YAML = """
+conditional_metric:
+  columns_include:
+    - a
+    - c
+    - e
+"""
+
+
+@pytest.fixture
+def config_default():
+    return load_config()
+
+
+@pytest.fixture
+def config_col_override(config_default):
+    conf = deepcopy(config_default)
+    extra = yaml.load(COLUMN_OVERRIDE_YAML, Loader=yaml.FullLoader)
+    conf["evaluations"]["conditional_metric"]["computation"]["columns"] = extra[
+        "columns"
+    ]
+    return conf
+
+
+@pytest.fixture
+def config_colname(config_col_override):
+    conf = deepcopy(config_col_override)
+    extra = yaml.load(COLNAME_LIST_YAML, Loader=yaml.FullLoader)
+    conf["evaluations"]["conditional_metric"]["columns_include"] = extra[
+        "conditional_metric"
+    ]["columns_include"]
+    return conf
+
+
+@pytest.fixture
+def result_class_no_display(monkeypatch):
+    class CMRPatched(ConditionalMetricResult):
+        def display_result(self, xlab, ylab):
+            print(f"{xlab}:{len(self.vals)}")
+
+    from presc.evaluations import conditional_metric
+
+    monkeypatch.setattr(conditional_metric, "ConditionalMetricResult", CMRPatched)
+
+
+def test_eval_compute_for_column(
+    test_dataset, classification_model, config_default, config_col_override
+):
+    # Defaults
+    cme = ConditionalMetric(classification_model, test_dataset, config_default)
+    cmr = cme.compute_for_column("a", metric=METRIC)
+    assert len(cmr.vals) == 10
+    assert cmr.num_bins == 10
+
+    # Column-specific override
+    cme = ConditionalMetric(classification_model, test_dataset, config_col_override)
+    cmr_a = cme.compute_for_column("a", metric=METRIC)
+    assert len(cmr_a.vals) == 5
+    assert cmr_a.num_bins == 5
+    cmr_b = cme.compute_for_column("b", metric=METRIC)
+    assert len(cmr_b.vals) == 10
+    assert cmr_b.num_bins == 10
+
+    # kwarg override
+    cmr_a = cme.compute_for_column("a", metric=METRIC, num_bins=4, quantile=True)
+    assert len(cmr_a.vals) == 4
+    assert cmr_a.num_bins == 4
+    assert cmr_a.quantile is True
+    cmr_b = cme.compute_for_column("b", metric=METRIC, num_bins=4)
+    assert len(cmr_b.vals) == 4
+    assert cmr_b.num_bins == 4
+
+
+def test_eval_display(
+    test_dataset,
+    classification_model,
+    config_default,
+    config_colname,
+    result_class_no_display,
+    capsys,
+):
+    cme = ConditionalMetric(classification_model, test_dataset, config_default)
+    cme.display()
+    cols_displayed = capsys.readouterr().out
+    assert len(cols_displayed.split()) == 5
+
+    cme.display(colnames=["a", "c"])
+    cols_displayed = capsys.readouterr().out
+    assert [x.strip() for x in cols_displayed.split()] == ["a:10", "c:3"]
+
+    cme = ConditionalMetric(classification_model, test_dataset, config_colname)
+    cme.display()
+    cols_displayed = capsys.readouterr().out
+    assert [x.strip() for x in cols_displayed.split()] == ["a:5", "c:3", "e:10"]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -8,6 +8,7 @@ def test_dataset(dataset_df):
 
     assert ds.size == 100
     assert ds.feature_names == ["a", "b", "c", "d", "e"]
+    assert ds.column_names == ["a", "b", "c", "d", "e"]
     assert_frame_equal(ds.features, dataset_df.drop(columns=["label"]))
     assert_series_equal(ds.labels, dataset_df["label"])
     assert ds.other_cols.size == 0
@@ -19,6 +20,7 @@ def test_dataset_other_cols(dataset_df):
 
     assert ds.size == 100
     assert ds.feature_names == ["a", "b", "d"]
+    assert ds.column_names == ["a", "b", "d", "c", "e"]
     assert_frame_equal(ds.features, dataset_df[["a", "b", "d"]])
     assert_series_equal(ds.labels, dataset_df["label"])
     assert_frame_equal(ds.other_cols, dataset_df[["c", "e"]])
@@ -26,6 +28,8 @@ def test_dataset_other_cols(dataset_df):
 
     ds.df["avg_col"] = (dataset_df["a"] + dataset_df["b"]) / 2
     assert_frame_equal(ds.other_cols, dataset_df[["c", "e", "avg_col"]])
+    assert ds.feature_names == ["a", "b", "d"]
+    assert ds.column_names == ["a", "b", "d", "c", "e", "avg_col"]
 
 
 def test_subset(dataset_df):
@@ -38,6 +42,7 @@ def test_subset(dataset_df):
     assert isinstance(ds_C, Dataset)
     assert ds_C.size == 15
     assert ds_C.feature_names == ["a", "b", "c", "d", "e"]
+    assert ds_C.column_names == ["a", "b", "c", "d", "e", "avg_col"]
     assert_series_equal(ds_C.labels, df.loc[df["c"] == "C", "label"])
     assert list(ds_C.other_cols.columns) == ["avg_col"]
     assert_frame_equal(ds_C.df, df[df["c"] == "C"])
@@ -47,6 +52,7 @@ def test_subset(dataset_df):
     assert isinstance(ds_ind, Dataset)
     assert ds_ind.size == 10
     assert ds_ind.feature_names == ["a", "b", "c", "d", "e"]
+    assert ds_ind.column_names == ["a", "b", "c", "d", "e", "avg_col"]
     assert_series_equal(ds_ind.labels, df.iloc[range(10)]["label"])
     assert list(ds_ind.other_cols.columns) == ["avg_col"]
     assert_frame_equal(ds_ind.df, df.iloc[range(10)])
@@ -55,6 +61,7 @@ def test_subset(dataset_df):
     assert isinstance(ds_pos, Dataset)
     assert ds_pos.size == 10
     assert ds_pos.feature_names == ["a", "b", "c", "d", "e"]
+    assert ds_pos.column_names == ["a", "b", "c", "d", "e", "avg_col"]
     assert_series_equal(ds_pos.labels, df.iloc[ii]["label"])
     assert list(ds_pos.other_cols.columns) == ["avg_col"]
     assert_frame_equal(ds_pos.df, df.iloc[ii])

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -11,6 +11,8 @@ import yaml
 from presc.report.runner import Context, ReportRunner, load_config
 from presc.utils import PrescError
 
+TEST_REPORT_CONFIG_PATH = Path(__file__).parent / "fixtures" / "config_test_report.yaml"
+
 
 @pytest.fixture
 def webbrowser_patched(monkeypatch):
@@ -105,7 +107,13 @@ def test_run_report(
     exec_path_run = tmp_path / "test_exec"
     rr = ReportRunner(output_path=out_path_run, execution_path=exec_path_run)
     # Run a report on the test data. This will take ~10 seconds
-    rr.run(model=classification_model, test_dataset=test_dataset)
+    # Use a custom config that reduces computation and is more appropriate for
+    # the small test dataset.
+    rr.run(
+        model=classification_model,
+        test_dataset=test_dataset,
+        config_filepath=TEST_REPORT_CONFIG_PATH,
+    )
 
     # Check top-level output files exist and paths resolve
     assert isinstance(rr._jb_build_result, CompletedProcess)
@@ -176,7 +184,11 @@ def test_run_report_tmp_exec_dir(tmp_path, classification_model, test_dataset):
     rr = ReportRunner(output_path=out_path_run)
     # Run a report using the using default temp execution dir.
     # This will take ~10 seconds
-    rr.run(model=classification_model, test_dataset=test_dataset)
+    rr.run(
+        model=classification_model,
+        test_dataset=test_dataset,
+        config_filepath=TEST_REPORT_CONFIG_PATH,
+    )
 
     # Just check that it worked.
     assert rr.report_main_page.exists()
@@ -189,7 +201,11 @@ def test_run_report_error_notebook(tmp_path, pipeline_classifier, test_dataset):
     exec_path_run = tmp_path / "test_exec"
     rr = ReportRunner(output_path=out_path_run, execution_path=exec_path_run)
     # pipeline_classifier is not a valid ClassificationModel instance
-    rr.run(model=pipeline_classifier, test_dataset=test_dataset)
+    rr.run(
+        model=pipeline_classifier,
+        test_dataset=test_dataset,
+        config_filepath=TEST_REPORT_CONFIG_PATH,
+    )
 
     # jupyter-book build job succeeded even though notebooks didn't
     assert rr._jb_build_result.returncode == 0
@@ -232,7 +248,11 @@ def test_run_report_error_build(
     rr = ReportRunner(output_path=out_path_run)
     # run() function generates warnings
     with pytest.warns(UserWarning) as warning_records:
-        rr.run(model=classification_model, test_dataset=test_dataset)
+        rr.run(
+            model=classification_model,
+            test_dataset=test_dataset,
+            config_filepath=TEST_REPORT_CONFIG_PATH,
+        )
     assert len(warning_records) == 2
     # Warning from build function
     first_warning = warning_records[0].message.args[0]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,16 +2,54 @@ import os
 from subprocess import CompletedProcess
 from pathlib import Path
 import shutil
+from copy import deepcopy
 
 from pandas.testing import assert_frame_equal
 import pytest
 from sklearn.pipeline import Pipeline
 import yaml
 
-from presc.report.runner import Context, ReportRunner, load_config
+from presc.report.runner import (
+    Context,
+    ReportRunner,
+    load_config,
+    _updated_jb_config,
+    _updated_jb_toc,
+)
 from presc.utils import PrescError
 
 TEST_REPORT_CONFIG_PATH = Path(__file__).parent / "fixtures" / "config_test_report.yaml"
+
+REPORT_CONFIG_YAML = """
+report:
+  title: abc
+  author: xyz
+  evaluations_exclude:
+    - landing
+    - conditional_metric
+"""
+
+
+@pytest.fixture
+def config_report(config_default):
+    conf = deepcopy(config_default["report"])
+    extra = yaml.load(REPORT_CONFIG_YAML, Loader=yaml.FullLoader)
+    conf.update(extra["report"])
+    return conf
+
+
+@pytest.fixture
+def config_override_report(config_default, config_report):
+    conf = deepcopy(config_default)
+    conf["report"] = config_report
+    return conf
+
+
+@pytest.fixture
+def config_error(config_default):
+    conf = deepcopy(config_default)
+    conf["evaluations"] = {"abc": 1}
+    return conf
 
 
 @pytest.fixture
@@ -73,6 +111,20 @@ def test_config(tmp_path):
 
     default_config = load_config()
     assert isinstance(default_config, dict)
+
+
+def test_update_jb_configs(config_report):
+    jb_config_str = _updated_jb_config(config_report)
+    jb_config = yaml.load(jb_config_str, Loader=yaml.FullLoader)
+    assert jb_config["title"] == "abc"
+    assert jb_config["author"] == "xyz"
+
+    jb_toc_str = _updated_jb_toc(config_report)
+    assert "landing" in jb_toc_str
+    assert "conditional_metric" not in jb_toc_str
+    assert "conditional_distribution" in jb_toc_str
+    # Check the result is valid YAML
+    yaml.load(jb_toc_str, Loader=yaml.FullLoader)
 
 
 def test_report_runner(tmp_path):
@@ -283,14 +335,16 @@ def test_run_report_error_build(
         rr.open()
 
 
-def test_run_report_error_config(tmp_path, classification_model, test_dataset):
+def test_run_report_error_config(
+    tmp_path, classification_model, test_dataset, config_error
+):
     # Passing in config file to run() overrides default config.
     # Fake config causes error.
     out_path_run = tmp_path / "test_run"
     exec_path_run = tmp_path / "test_exec"
     fake_config_file = tmp_path / "fake_config.yaml"
     with open(fake_config_file, "w") as f:
-        yaml.dump({"fake_option": 123}, f)
+        yaml.dump(config_error, f)
 
     rr = ReportRunner(output_path=out_path_run, execution_path=exec_path_run)
     rr.run(
@@ -323,3 +377,45 @@ def test_run_report_error_config(tmp_path, classification_model, test_dataset):
         eval_html = f.read()
     assert "Error" in eval_html
     assert "Traceback" in eval_html
+
+
+def test_run_report_override_config(
+    tmp_path, classification_model, test_dataset, config_override_report
+):
+    out_path_run = tmp_path / "test_run"
+    exec_path_run = tmp_path / "test_exec"
+    config_path = tmp_path / "custom_config.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump(config_override_report, f)
+
+    rr = ReportRunner(
+        output_path=out_path_run,
+        execution_path=exec_path_run,
+        config_filepath=config_path,
+    )
+    rr.run(
+        model=classification_model,
+        test_dataset=test_dataset,
+    )
+
+    # Report ran successfully.
+    assert rr._jb_build_result.returncode == 0
+    with open(rr.jb_build_log) as f:
+        build_log = f.read()
+    assert build_log.startswith("Running Jupyter-Book")
+    assert "Finished generating HTML" in build_log
+    assert "error" not in build_log.lower()
+    assert "failed" not in build_log.lower()
+
+    # Excluded page was not rendered.
+    assert rr.report_main_page.exists()
+    output_files = os.listdir(rr.report_main_page.parent)
+    assert "landing.html" in output_files
+    assert "conditional_metric.html" not in output_files
+    assert "conditional_distribution.html" in output_files
+
+    # Overridden attributes got picked up in the report pages.
+    with open(rr.report_main_page.with_name("landing.html")) as f:
+        landing_html = f.read()
+    assert "abc</title>" in landing_html
+    assert "By xyz" in landing_html

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+from presc.utils import include_exclude_list
+
+
+def test_include_exclude():
+    vals = ["a", "b", "c", "d", "e"]
+
+    assert include_exclude_list(vals) == vals
+    assert include_exclude_list(vals, included=vals) == vals
+    assert include_exclude_list(vals, included=None) == []
+    assert include_exclude_list(vals, excluded="*") == []
+    assert include_exclude_list(vals, excluded=vals) == []
+
+    assert include_exclude_list(vals, included=["c", "b", "e", "y"]) == ["c", "b", "e"]
+    assert include_exclude_list(vals, excluded=["a", "e", "z"]) == ["b", "c", "d"]
+    assert include_exclude_list(
+        vals, included=["c", "b", "e", "y"], excluded=["e"]
+    ) == ["c", "b"]
+    assert include_exclude_list(vals, included=["c", "b", "e", "y"], excluded="*") == []
+    assert include_exclude_list(vals, included=None, excluded=["a"]) == []


### PR DESCRIPTION
The config structure now supports controlling the pages showing in the report, the columns for which the evaluations are computed, and per-column overrides for the computation options.

The pattern I went with for config in the evaluations is:

- the `compute_` module function takes all options as explicit params and stores them as attributes in the Result instance
- the evaluation main class takes options from a config dictionary, but may allow for overrides via kwargs

The main class is the main entrypoint to running the evaluation as is on a given dataset, and the `compute_` top-level function exposes the underlying computation for exploration/development purposes.

The tests I added for the evaluations only check that the config settings get picked up. The actual computations are not yet tested (this is still an open issue).