### PR TITLE
Closes #258: Added user specified metrics

### DIFF
--- a/presc/config_default.yaml
+++ b/presc/config_default.yaml
@@ -24,8 +24,6 @@ evaluations:
     metrics:
       - function: accuracy_score
         display_name: Accuracy
-      - function: jaccard_score
-        display_name: Jaccard Score
     computation:
       # Number of bins for partitioning a numeric column
       num_bins: 10

--- a/presc/config_default.yaml
+++ b/presc/config_default.yaml
@@ -21,6 +21,11 @@ evaluations:
     # Results will be ordered according to `columns_include`.
     columns_include: "*"
     columns_exclude: null
+    metrics:
+      - function: accuracy_score
+        display_name: Accuracy
+      - function: jaccard_score
+        display_name: Jaccard Score
     computation:
       # Number of bins for partitioning a numeric column
       num_bins: 10


### PR DESCRIPTION
Closes #258

Added functionality to allow user to define the metric function used in the analysis.  The metrics used can be specified in the config_default.yaml file 

- Multiple functions with an optional label can be specified.  If no label is provided the function name is used.
```
metrics:
  - function: accuracy_score
    display_name: Accuracy
  - function: jaccard_score
    display_name: Jaccard Score
```
- A per column override is provided.  Specifying per column metrics results in only those functions used as metrics for that column and is not in addition to the default functions.
```
columns:
  density:
    metrics:
      - function: jaccard_score
        display_name: Jaccard Score
```