### PR TITLE
Install jupyter-book with conda to fix dependency issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,9 @@ dependencies:
   - scikit-learn=0.23.1
   - scipy=1.4.1
   - jupyter=1.0.0
+  - jupyter-book=0.10.1
   - matplotlib=3.3.2
+  - m2r2=0.2.7
   - seaborn=0.11.0
   - pip=20.0.2
   - plotnine=0.6.0
@@ -18,12 +20,9 @@ dependencies:
   - pytest=5.4.3
   - pytest-cov=2.10.0
   - pyyaml=5.4.1
+  - sphinx=3.5.3
   - twine=3.2.0
   - imbalanced-learn=0.7.0
   - pandas-profiling=2.8.0
   - pip:
-    - jupyter-book==0.9.1
     - sphinx-rtd-theme==0.5.1
-    - m2r2==0.2.7
-
-


### PR DESCRIPTION
There was an incompatibility in the environment due to a conflict between conda and pip which was causing a CI failure. This seemed to be caused by the installation of `jupyter-book` with pip and the additional dependencies it adds. Since `jupyter-book` is now available on conda, let's install from there.

Additional changes:
- Move `m2r2` to conda as it is now available
- Add explicit entry for Sphinx since we are using it directly for the docs
- Use a newer version of `jupyter-book` since 0.9.1 is not on conda. Note that this is for the dev environment but does not affect the package requirements (`jupyter-book>=0.9.1`)