### PR TITLE
Copies with categorical data

### DIFF
--- a/presc/copies/copying.py
+++ b/presc/copies/copying.py
@@ -117,7 +117,7 @@ class ClassifierCopy:
             ]
 
         X_generated = mixed_data_sampling(
-            self.sampling_function, **k_sampling_parameters_gen
+            numerical_sampling=self.sampling_function, **k_sampling_parameters_gen
         )
 
         # If the type of sampling function attempts to balance the synthetic

--- a/presc/copies/copying.py
+++ b/presc/copies/copying.py
@@ -24,7 +24,9 @@ class ClassifierCopy:
             ML classifier that will be used for the copy.
         sampling_function : function
             Any of the sampling functions defined in PRESC: `grid_sampling`,
-            `uniform_sampling`, `normal_sampling`...
+            `uniform_sampling`, `normal_sampling`... The `balancing sampler` can
+            only be used if the feature space does not contain any categorical
+            variable.
         balancing_sampler: bool
             Whether the chosen sampling function does class balancing or not.
         label_col : str
@@ -85,8 +87,10 @@ class ClassifierCopy:
         """Generates synthetic data using the original model.
 
         Generates samples following the sampling strategy specified on
-        instantiation and then labels them using the original model. If the same
-        data needs to be generated then simply use a specific random seed.
+        instantiation for the numerical features and a discrete distribution for
+        the categorical features, and then labels them using the original model.
+        If the same data needs to be generated then simply use a specific
+        random seed.
 
         Parameters
         ----------

--- a/presc/copies/copying.py
+++ b/presc/copies/copying.py
@@ -1,5 +1,5 @@
 from presc.dataset import Dataset
-from presc.copies.sampling import labeling
+from presc.copies.sampling import mixed_data_sampling, labeling
 from presc.copies.evaluations import (
     empirical_fidelity_error,
     replacement_capability,
@@ -112,7 +112,9 @@ class ClassifierCopy:
                 "random_state"
             ]
 
-        X_generated = self.sampling_function(**k_sampling_parameters_gen)
+        X_generated = mixed_data_sampling(
+            self.sampling_function, **k_sampling_parameters_gen
+        )
 
         # If the type of sampling function attempts to balance the synthetic
         # dataset, it returns the features AND the labels. Otherwise, it returns

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -410,7 +410,31 @@ def spherical_balancer_sampling(
 
 
 def categorical_sampling(nsamples=500, random_state=None, feature_parameters=None):
-    """."""
+    """Sample de classifier with a discrete distribution sampling.
+
+    Generates synthetic samples with a discrete distribution according to the
+    probabilities described by `feature_parameters`. Features are assumed to be
+    independent (not correlated).
+
+    Parameters
+    ----------
+    nsamples : int
+        Number of samples to generate.
+    random_state : int
+        Random seed used to generate the sampling data.
+    feature_parameters : dict of dicts
+        A dictionary with an entry per dataset feature (dictionary keys should
+        be the feature names), where each feature entry must contain a
+        nested dictionary with its categories and their fraction. The key for
+        the nested dictionary of categories should be "categories", and the keys
+        for the fractions should be the category name.
+
+    Returns
+    -------
+    pandas DataFrame
+        Dataset with a generated sampling following the discrete distribution of
+        the feature space characterized by the `feature_parameters`.
+    """
     if random_state is not None:
         np.random.seed(seed=random_state)
 

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -522,16 +522,10 @@ def mixed_data_sampling(
 
     # Combine the numerical/categorical features respecting the structure of the
     # original dataset
-    X_generated = pd.DataFrame()
-    for feature in feature_parameters:
-        if "categories" in feature_parameters[feature]:
-            X_generated = X_generated.join(
-                X_generated_categorical[[feature]], how="outer"
-            )
-        else:
-            X_generated = X_generated.join(
-                X_generated_numerical[[feature]], how="outer"
-            )
+    X_generated = pd.concat(
+        [X_generated_numerical, X_generated_categorical], axis="columns"
+    )
+    X_generated = X_generated[feature_parameters.keys()]
 
     return X_generated
 

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -500,6 +500,7 @@ def mixed_data_sampling(
         else:
             features_numerical.append(feature)
 
+    # Generate feature parameter dictionaries for the numerical/categorical samplers
     feature_parameters_numerical = {
         feature: feature_parameters[feature] for feature in features_numerical
     }
@@ -507,6 +508,7 @@ def mixed_data_sampling(
         feature: feature_parameters[feature] for feature in features_categorical
     }
 
+    # Generate the numerical/categorical features of each sample separately
     X_generated_numerical = numerical_sampling(
         nsamples=nsamples,
         random_state=random_state,
@@ -517,6 +519,9 @@ def mixed_data_sampling(
         random_state=random_state,
         feature_parameters=feature_parameters_categorical,
     )
+
+    # Combine the numerical/categorical features respecting the structure of the
+    # original dataset
     X_generated = pd.DataFrame()
     for feature in feature_parameters:
         if "categories" in feature_parameters[feature]:

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -117,6 +117,30 @@ def build_equal_category_dict(feature_categories):
 
 
 def mixed_data_features(df, add_NaNs=False):
+    """Extracts the numerical/categorical feature parameters from a dataset.
+
+    Parameters
+    ----------
+    df : pandas DataFrame
+        The dataset with all the features to analyze (both numerical and
+        categorical).
+    add_NaNs : bool
+        If True the sampler adds a "NaNs" category for the categorical features
+        that have any null values and assigns it the appropriate fraction.
+
+    Returns
+    -------
+    dict of dicts
+        A dictionary with an entry per dataset feature (dictionary keys are the
+        column names), where each numerical feature entry contains a nested
+        dictionary with the values of the minimum and maximum values of the
+        dynamic range of the dataset, as well as the mean and sigma of the
+        distribution, and each categorical feature entry contains a nested
+        dictionary with its categories and the fraction of each category present
+        in the analyzed dataset (nested dictionary keys are "min", "max",
+        "mean", "sigma", and "categories", which is also a dictionary with one
+        entry per category).
+    """
     features_dict = {}
     for feature in df:
         df_feature = df[[feature]]

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -41,14 +41,14 @@ def dynamical_range(df):
     return range_dict
 
 
-def find_categories(df, add_NaNs=False):
+def find_categories(df, add_nans=False):
     """Returns the categories of the dataset features.
 
     Parameters
     ----------
     df : pandas DataFrame
         The dataset with all the categorical features to analyze.
-    add_NaNs : bool
+    add_nans : bool
         If True the sampler adds a "NaNs" category for the features that have
         any null values and assigns it the appropriate fraction.
 
@@ -68,7 +68,7 @@ def find_categories(df, add_NaNs=False):
             df_no_nans = df[df[feature].notnull()]
 
             # Log fraction of NaN values if required
-            if add_NaNs:
+            if add_nans:
                 nan_fraction = df[feature].isnull().sum() / len(df)
                 total_length = len(df)
             else:
@@ -84,7 +84,7 @@ def find_categories(df, add_NaNs=False):
                 categories_dict[feature]["categories"][category] = (
                     df_no_nans[feature].value_counts()[category] / total_length
                 )
-            if add_NaNs and nan_fraction != 0:
+            if add_nans and nan_fraction != 0:
                 categories_dict[feature]["categories"]["NaNs"] = nan_fraction
 
     return categories_dict
@@ -116,7 +116,7 @@ def build_equal_category_dict(feature_categories):
     return categories_dict
 
 
-def mixed_data_features(df, add_NaNs=False):
+def mixed_data_features(df, add_nans=False):
     """Extracts the numerical/categorical feature parameters from a dataset.
 
     Parameters
@@ -124,7 +124,7 @@ def mixed_data_features(df, add_NaNs=False):
     df : pandas DataFrame
         The dataset with all the features to analyze (both numerical and
         categorical).
-    add_NaNs : bool
+    add_nans : bool
         If True the sampler adds a "NaNs" category for the categorical features
         that have any null values and assigns it the appropriate fraction.
 
@@ -145,7 +145,7 @@ def mixed_data_features(df, add_NaNs=False):
     for feature in df:
         df_feature = df[[feature]]
         if is_discrete(df[feature]):
-            single_feature_parameters = find_categories(df_feature, add_NaNs=add_NaNs)
+            single_feature_parameters = find_categories(df_feature, add_nans=add_nans)
         else:
             single_feature_parameters = dynamical_range(df_feature)
         features_dict[feature] = single_feature_parameters[feature]

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -91,6 +91,23 @@ def find_categories(df, add_NaNs=False):
 
 
 def build_equal_category_dict(feature_categories):
+    """Assigns equal probability to all categories of each feature.
+
+    Parameters
+    ----------
+    feature_categories : dict of lists
+        A dictionary with an entry per feature, with the list of categories
+        that each feature has.
+
+    Returns
+    -------
+    dict of dicts
+        A dictionary with an entry per dataset feature (dictionary keys are the
+        column names), where each feature entry contains a nested dictionary
+        with its categories and the identical fraction for all categories from
+        the same feature (the nested dictionary key for this information is
+        "categories", which is also a dictionary with one entry per category).
+    """
     categories_dict = {}
     for feature, categories in feature_categories.items():
         categories_dict[feature] = {

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -349,6 +349,27 @@ def spherical_balancer_sampling(
     return df_generated
 
 
+def categorical_sampling(nsamples=500, random_state=None, feature_parameters=None):
+    """."""
+    if random_state is not None:
+        np.random.seed(seed=random_state)
+
+    # Generate random data with the probabilities specified on the "categories"
+    # entry of the feature_parameters
+    X_generated = pd.DataFrame()
+    for feature in feature_parameters:
+        categories = list(feature_parameters[feature]["categories"].keys())
+        category_probabilities = [
+            feature_parameters[feature]["categories"][category]
+            for category in categories
+        ]
+        X_generated[feature] = pd.Series(
+            np.random.choice(categories, p=category_probabilities, size=nsamples)
+        ).astype("category")
+
+    return X_generated
+
+
 def labeling(X, original_classifier, label_col="class"):
     """Labels the samples from a dataset according to a classifier.
 

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -410,7 +410,7 @@ def spherical_balancer_sampling(
 
 
 def categorical_sampling(nsamples=500, random_state=None, feature_parameters=None):
-    """Sample de classifier with a discrete distribution sampling.
+    """Sample the classifier with a discrete distribution sampling.
 
     Generates synthetic samples with a discrete distribution according to the
     probabilities described by `feature_parameters`. Features are assumed to be
@@ -438,8 +438,7 @@ def categorical_sampling(nsamples=500, random_state=None, feature_parameters=Non
     if random_state is not None:
         np.random.seed(seed=random_state)
 
-    # Generate random data with the probabilities specified on the "categories"
-    # entry of the feature_parameters
+    # Generate random data with the specified probabilities
     X_generated = pd.DataFrame()
     for feature in feature_parameters:
         categories = list(feature_parameters[feature]["categories"].keys())
@@ -457,7 +456,38 @@ def categorical_sampling(nsamples=500, random_state=None, feature_parameters=Non
 def mixed_data_sampling(
     numerical_sampling, nsamples=500, random_state=None, feature_parameters=None
 ):
-    """."""
+    """Sample the classifier with a mix of a numerical and categorical sampler.
+
+    Generates synthetic samples with the specified distribution for the
+    numerical features and with a discrete distribution for the categorical
+    features. The parameters describing the feature space needed to compute the
+    distributions are described in the `feature_parameters` dictionary. Features
+    are assumed to be independent (not correlated).
+
+    Parameters
+    ----------
+    numerical_sampling : function
+        Any of the non balancing numerical sampling functions defined in PRESC:
+        `grid_sampling`, `uniform_sampling`, `normal_sampling`...
+    nsamples : int
+        Number of samples to generate.
+    random_state : int
+        Random seed used to generate the sampling data.
+    feature_parameters : dict of dicts
+        A dictionary with an entry per dataset feature (dictionary keys should
+        be the feature names), where each feature entry must contain a
+        nested dictionary with its categories and their probability. The key for
+        the nested dictionary of categories should be "categories", and the keys
+        for the probabilities should be the category name.
+
+    Returns
+    -------
+    pandas DataFrame
+        Dataset with a generated sampling following the specified numerical
+        sampling distribution for the numerical features and the discrete
+        distribution for the categorical features, following the feature space
+        characterized by the `feature_parameters`.
+    """
     if random_state is not None:
         np.random.seed(seed=random_state)
 

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -153,7 +153,7 @@ def mixed_data_features(df, add_nans=False):
     return features_dict
 
 
-def grid_sampling(nsamples=500, random_state=None, feature_parameters=None):
+def grid_sampling(feature_parameters, nsamples=500, random_state=None):
     """Sample the classifier with a grid-like sampling.
 
     Generates synthetic samples with a regular grid-like distribution within the
@@ -162,17 +162,17 @@ def grid_sampling(nsamples=500, random_state=None, feature_parameters=None):
 
     Parameters
     ----------
-    nsamples : int
-        Maximum number of samples to generate. The exact number will depend on
-        the parameter space.
-    random_state : int
-        Parameter not used in `grid_sampling`.
     feature_parameters : dict of dicts
         A dictionary with an entry per dataset feature (dictionary keys should
         be the feature names), and where each feature entry must contain a
         nested dictionary with at least the entries corresponding to the minimum
         and maximum values of the dynamic range. Dictionary keys for these
         values should be "min" and "max", respectively.
+    nsamples : int
+        Maximum number of samples to generate. The exact number will depend on
+        the parameter space.
+    random_state : int
+        Parameter not used in `grid_sampling`.
 
     Returns
     -------
@@ -203,7 +203,7 @@ def grid_sampling(nsamples=500, random_state=None, feature_parameters=None):
     return X_generated
 
 
-def uniform_sampling(nsamples=500, random_state=None, feature_parameters=None):
+def uniform_sampling(feature_parameters, nsamples=500, random_state=None):
     """Sample the classifier with a random uniform sampling.
 
     Generates synthetic samples with a random uniform distribution within the
@@ -211,16 +211,16 @@ def uniform_sampling(nsamples=500, random_state=None, feature_parameters=None):
 
     Parameters
     ----------
-    nsamples : int
-        Number of samples to generate.
-    random_state : int
-        Random seed used to generate the sampling data.
     feature_parameters : dict of dicts
         A dictionary with an entry per dataset feature (dictionary keys should
         be the feature names), and where each feature entry must contain a
         nested dictionary with at least the entries corresponding to the minimum
         and maximum values of the dynamic range. Dictionary keys for these
         values should be "min" and "max", respectively.
+    nsamples : int
+        Number of samples to generate.
+    random_state : int
+        Random seed used to generate the sampling data.
 
     Returns
     -------
@@ -244,9 +244,9 @@ def uniform_sampling(nsamples=500, random_state=None, feature_parameters=None):
 
 
 def normal_sampling(
+    feature_parameters,
     nsamples=500,
     random_state=None,
-    feature_parameters=None,
 ):
     """Sample the classifier with a normal distribution sampling.
 
@@ -256,16 +256,16 @@ def normal_sampling(
 
     Parameters
     ----------
-    nsamples : int
-        Number of samples to generate.
-    random_state : int
-        Random seed used to generate the sampling data.
     feature_parameters : dict of dicts
         A dictionary with an entry per dataset feature (dictionary keys should
         be the feature names), and where each feature entry must contain a
         nested dictionary with at least the entries corresponding to the mean
         and standard deviation values of the dataset. Dictionary keys for these
         values should be "mean" and "sigma", respectively.
+    nsamples : int
+        Number of samples to generate.
+    random_state : int
+        Random seed used to generate the sampling data.
 
     Returns
     -------
@@ -409,7 +409,7 @@ def spherical_balancer_sampling(
     return df_generated
 
 
-def categorical_sampling(nsamples=500, random_state=None, feature_parameters=None):
+def categorical_sampling(feature_parameters, nsamples=500, random_state=None):
     """Sample the classifier with a discrete distribution sampling.
 
     Generates synthetic samples with a discrete distribution according to the
@@ -418,16 +418,16 @@ def categorical_sampling(nsamples=500, random_state=None, feature_parameters=Non
 
     Parameters
     ----------
-    nsamples : int
-        Number of samples to generate.
-    random_state : int
-        Random seed used to generate the sampling data.
     feature_parameters : dict of dicts
         A dictionary with an entry per dataset feature (dictionary keys should
         be the feature names), where each feature entry must contain a
         nested dictionary with its categories and their fraction. The key for
         the nested dictionary of categories should be "categories", and the keys
         for the fractions should be the category name.
+    nsamples : int
+        Number of samples to generate.
+    random_state : int
+        Random seed used to generate the sampling data.
 
     Returns
     -------
@@ -454,7 +454,7 @@ def categorical_sampling(nsamples=500, random_state=None, feature_parameters=Non
 
 
 def mixed_data_sampling(
-    numerical_sampling, nsamples=500, random_state=None, feature_parameters=None
+    feature_parameters, numerical_sampling, nsamples=500, random_state=None
 ):
     """Sample the classifier with a mix of a numerical and categorical sampler.
 
@@ -466,6 +466,12 @@ def mixed_data_sampling(
 
     Parameters
     ----------
+    feature_parameters : dict of dicts
+        A dictionary with an entry per dataset feature (dictionary keys should
+        be the feature names), where each feature entry must contain a
+        nested dictionary with its categories and their probability. The key for
+        the nested dictionary of categories should be "categories", and the keys
+        for the probabilities should be the category name.
     numerical_sampling : function
         Any of the non balancing numerical sampling functions defined in PRESC:
         `grid_sampling`, `uniform_sampling`, `normal_sampling`...
@@ -473,12 +479,6 @@ def mixed_data_sampling(
         Number of samples to generate.
     random_state : int
         Random seed used to generate the sampling data.
-    feature_parameters : dict of dicts
-        A dictionary with an entry per dataset feature (dictionary keys should
-        be the feature names), where each feature entry must contain a
-        nested dictionary with its categories and their probability. The key for
-        the nested dictionary of categories should be "categories", and the keys
-        for the probabilities should be the category name.
 
     Returns
     -------

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -438,6 +438,7 @@ def labeling(X, original_classifier, label_col="class"):
 
     # Label synthetic data with original classifier
     df_labeled[label_col] = original_classifier.predict(df_labeled)
+    df_labeled[label_col] = df_labeled[label_col].astype("category")
 
     # Instantiate dataset wrapper
     df_labeled = Dataset(df_labeled, label_col=label_col)

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -10,7 +10,7 @@ def dynamical_range(df):
     Parameters
     ----------
     df : pandas DataFrame
-        The dataset with all the features to analyze.
+        The dataset with all the numerical features to analyze.
 
     Returns
     -------
@@ -42,6 +42,25 @@ def dynamical_range(df):
 
 
 def find_categories(df, add_NaNs=False):
+    """Returns the categories of the dataset features.
+
+    Parameters
+    ----------
+    df : pandas DataFrame
+        The dataset with all the categorical features to analyze.
+    add_NaNs : bool
+        If True the sampler adds a "NaNs" category for the features that have
+        any null values and assigns it the appropriate fraction.
+
+    Returns
+    -------
+    dict of dicts
+        A dictionary with an entry per dataset feature (dictionary keys are the
+        column names), where each feature entry contains a nested dictionary
+        with its categories and the fraction of each category present in the
+        analyzed dataset (the nested dictionary key for this information is
+        "categories", which is also a dictionary with one entry per category).
+    """
     categories_dict = {}
     for feature in df:
         if is_discrete(df[feature]):

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -370,6 +370,53 @@ def categorical_sampling(nsamples=500, random_state=None, feature_parameters=Non
     return X_generated
 
 
+def mixed_data_sampling(
+    numerical_sampling, nsamples=500, random_state=None, feature_parameters=None
+):
+    """."""
+    if random_state is not None:
+        np.random.seed(seed=random_state)
+
+    # Generate the lists of numerical and categorical data
+    features_numerical = []
+    features_categorical = []
+    for feature in feature_parameters:
+        if "categories" in feature_parameters[feature]:
+            features_categorical.append(feature)
+        else:
+            features_numerical.append(feature)
+
+    feature_parameters_numerical = {
+        feature: feature_parameters[feature] for feature in features_numerical
+    }
+    feature_parameters_categorical = {
+        feature: feature_parameters[feature] for feature in features_categorical
+    }
+
+    X_generated_numerical = numerical_sampling(
+        nsamples=nsamples,
+        random_state=random_state,
+        feature_parameters=feature_parameters_numerical,
+    )
+    X_generated_categorical = categorical_sampling(
+        nsamples=nsamples,
+        random_state=random_state,
+        feature_parameters=feature_parameters_categorical,
+    )
+    X_generated = pd.DataFrame()
+    for feature in feature_parameters:
+        if "categories" in feature_parameters[feature]:
+            X_generated = X_generated.join(
+                X_generated_categorical[[feature]], how="outer"
+            )
+        else:
+            X_generated = X_generated.join(
+                X_generated_numerical[[feature]], how="outer"
+            )
+
+    return X_generated
+
+
 def labeling(X, original_classifier, label_col="class"):
     """Labels the samples from a dataset according to a classifier.
 

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -80,6 +80,19 @@ def build_equal_category_dict(feature_categories):
     return categories_dict
 
 
+def mixed_data_features(df, add_NaNs=False):
+    features_dict = {}
+    for feature in df:
+        df_feature = df[[feature]]
+        if is_discrete(df[feature]):
+            single_feature_parameters = find_categories(df_feature, add_NaNs=add_NaNs)
+        else:
+            single_feature_parameters = dynamical_range(df_feature)
+        features_dict[feature] = single_feature_parameters[feature]
+
+    return features_dict
+
+
 def grid_sampling(nsamples=500, random_state=None, feature_parameters=None):
     """Sample the classifier with a grid-like sampling.
 

--- a/presc/copies/sampling.py
+++ b/presc/copies/sampling.py
@@ -71,6 +71,15 @@ def find_categories(df, add_NaNs=False):
     return categories_dict
 
 
+def build_equal_category_dict(feature_categories):
+    categories_dict = {}
+    for feature, categories in feature_categories.items():
+        categories_dict[feature] = {
+            "categories": {key: 1 / len(categories) for key in categories}
+        }
+    return categories_dict
+
+
 def grid_sampling(nsamples=500, random_state=None, feature_parameters=None):
     """Sample the classifier with a grid-like sampling.
 

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -220,8 +220,8 @@ def test_mixed_data_sampling():
         nsamples=10000,
         random_state=2,
     )
+    assert list(feature_parameters.keys()) == list(data_generated.columns)
     for key in feature_parameters:
-        assert key in data_generated.columns
         if "categories" in feature_parameters[key]:
             for category in feature_parameters[key]["categories"]:
                 obtained_fraction = (

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -142,15 +142,9 @@ def test_grid_sampling():
         "feat_1": {"min": 0, "max": 2},
         "feat_2": {"min": 20, "max": 40},
     }
-    df_test_1 = grid_sampling(
-        nsamples=342, random_state=2, feature_parameters=feature_parameters
-    )
-    df_test_2 = grid_sampling(
-        nsamples=342, random_state=2, feature_parameters=feature_parameters
-    )
-    df_test_3 = grid_sampling(
-        nsamples=342, random_state=6, feature_parameters=feature_parameters
-    )
+    df_test_1 = grid_sampling(feature_parameters, nsamples=342, random_state=2)
+    df_test_2 = grid_sampling(feature_parameters, nsamples=342, random_state=2)
+    df_test_3 = grid_sampling(feature_parameters, nsamples=342, random_state=6)
 
     assert len(df_test_1) == 324
     assert len(df_test_1["feat_1"].unique()) == len(
@@ -167,15 +161,9 @@ def test_uniform_sampling():
         "feat_1": {"min": 0, "max": 2},
         "feat_2": {"min": 20, "max": 40},
     }
-    df_test_1 = uniform_sampling(
-        nsamples=342, random_state=2, feature_parameters=feature_parameters
-    )
-    df_test_2 = uniform_sampling(
-        nsamples=342, random_state=2, feature_parameters=feature_parameters
-    )
-    df_test_3 = uniform_sampling(
-        nsamples=342, random_state=6, feature_parameters=feature_parameters
-    )
+    df_test_1 = uniform_sampling(feature_parameters, nsamples=342, random_state=2)
+    df_test_2 = uniform_sampling(feature_parameters, nsamples=342, random_state=2)
+    df_test_3 = uniform_sampling(feature_parameters, nsamples=342, random_state=6)
 
     assert len(df_test_1) == 342
     assert df_test_1.equals(df_test_2) is True
@@ -189,15 +177,9 @@ def test_normal_sampling():
         "feat_1": {"mean": 0, "sigma": 2},
         "feat_2": {"mean": 20, "sigma": 40},
     }
-    df_test_1 = normal_sampling(
-        nsamples=342, random_state=2, feature_parameters=feature_parameters
-    )
-    df_test_2 = normal_sampling(
-        nsamples=342, random_state=2, feature_parameters=feature_parameters
-    )
-    df_test_3 = normal_sampling(
-        nsamples=342, random_state=6, feature_parameters=feature_parameters
-    )
+    df_test_1 = normal_sampling(feature_parameters, nsamples=342, random_state=2)
+    df_test_2 = normal_sampling(feature_parameters, nsamples=342, random_state=2)
+    df_test_3 = normal_sampling(feature_parameters, nsamples=342, random_state=6)
 
     assert len(df_test_1) == 342
     assert df_test_1.equals(df_test_2) is True
@@ -208,13 +190,13 @@ def test_normal_sampling():
     np.testing.assert_almost_equal(df_test_1["feat_2"].std(), 40, decimal=0)
 
 
-def test_categorical_sampling(nsamples=500, random_state=2, feature_parameters=None):
+def test_categorical_sampling():
     feature_parameters = {
         "feat_1": {"categories": {"red": 0.5, "blue": 0.5}},
         "feat_2": {"categories": {1: 0.3, 3: 0.6, 69: 0.1}},
     }
     data_generated = categorical_sampling(
-        nsamples=10000, random_state=2, feature_parameters=feature_parameters
+        feature_parameters, nsamples=10000, random_state=2
     )
     for key in feature_parameters:
         assert key in data_generated.columns
@@ -233,10 +215,10 @@ def test_mixed_data_sampling():
         "feat_2": {"mean": 20, "sigma": 40},
     }
     data_generated = mixed_data_sampling(
+        feature_parameters,
         normal_sampling,
         nsamples=10000,
         random_state=2,
-        feature_parameters=feature_parameters,
     )
     for key in feature_parameters:
         assert key in data_generated.columns

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+import pytest
 
 from sklearn.dummy import DummyClassifier
 from sklearn.svm import SVC
@@ -9,9 +10,14 @@ from presc.dataset import Dataset
 
 from presc.copies.sampling import (
     dynamical_range,
+    find_categories,
+    build_equal_category_dict,
+    mixed_data_features,
     grid_sampling,
     uniform_sampling,
     normal_sampling,
+    categorical_sampling,
+    mixed_data_sampling,
     labeling,
 )
 from presc.copies.evaluations import (
@@ -45,6 +51,90 @@ def test_dynamical_range():
                 expected_range_dict[key][descriptor],
                 significant=3,
             )
+
+
+def test_find_categories():
+    data = {
+        "color": ["red", "blue", "red", "blue", "blue"],
+        "height": [70.5, 80.3, 55.8, 65.1, 65.4],
+        "siblings": [1, 1, 1, 2, np.nan],
+    }
+    df = pd.DataFrame(data, columns=["color", "height", "siblings"])
+    df[["color", "siblings"]] = df[["color", "siblings"]].astype("category")
+    category_dict = find_categories(df, add_NaNs=True)
+    expected_category_dict = {
+        "color": {"categories": {"red": 0.4, "blue": 0.6}},
+        "siblings": {"categories": {1.0: 0.6, 2.0: 0.2, "NaNs": 0.2}},
+    }
+    assert category_dict.keys() == expected_category_dict.keys()
+    for key in category_dict:
+        assert (
+            category_dict[key]["categories"].keys()
+            == expected_category_dict[key]["categories"].keys()
+        )
+        for descriptor in category_dict[key]["categories"]:
+            np.testing.assert_approx_equal(
+                category_dict[key]["categories"][descriptor],
+                expected_category_dict[key]["categories"][descriptor],
+                significant=3,
+            )
+
+
+def test_build_equal_category_dict():
+    category_lists = {"color": ["red", "blue"], "siblings": [0, 1, 2, 5, 9]}
+    category_dict = build_equal_category_dict(category_lists)
+    expected_category_dict = {
+        "color": {"categories": {"red": 0.5, "blue": 0.5}},
+        "siblings": {"categories": {0: 0.2, 1: 0.2, 2: 0.2, 5: 0.2, 9: 0.2}},
+    }
+    assert category_dict.keys() == expected_category_dict.keys()
+    for key in category_dict:
+        assert (
+            category_dict[key]["categories"].keys()
+            == expected_category_dict[key]["categories"].keys()
+        )
+        for descriptor in category_dict[key]["categories"]:
+            np.testing.assert_approx_equal(
+                category_dict[key]["categories"][descriptor],
+                expected_category_dict[key]["categories"][descriptor],
+                significant=3,
+            )
+
+
+def test_mixed_data_features():
+    data = {
+        "color": ["red", "blue", "red", "blue", "blue"],
+        "height": [70.5, 80.3, 55.8, 65.1, 65.4],
+        "siblings": [1, 1, 1, 2, np.nan],
+    }
+    df = pd.DataFrame(data, columns=["color", "height", "siblings"])
+    df[["color", "siblings"]] = df[["color", "siblings"]].astype("category")
+    feature_dict = mixed_data_features(df, add_NaNs=True)
+    expected_feature_dict = {
+        "color": {"categories": {"red": 0.4, "blue": 0.6}},
+        "height": {"min": 55.8, "max": 80.3, "mean": 67.42, "sigma": 8.94242696},
+        "siblings": {"categories": {1.0: 0.6, 2.0: 0.2, "NaNs": 0.2}},
+    }
+    assert feature_dict.keys() == expected_feature_dict.keys()
+    for key in feature_dict:
+        if "categories" in key:
+            assert (
+                feature_dict[key]["categories"].keys()
+                == expected_feature_dict[key]["categories"].keys()
+            )
+            for descriptor in feature_dict[key]["categories"]:
+                np.testing.assert_approx_equal(
+                    feature_dict[key]["categories"][descriptor],
+                    expected_feature_dict[key]["categories"][descriptor],
+                    significant=3,
+                )
+        for descriptor in feature_dict[key]:
+            if descriptor != "categories":
+                np.testing.assert_approx_equal(
+                    feature_dict[key][descriptor],
+                    expected_feature_dict[key][descriptor],
+                    significant=3,
+                )
 
 
 def test_grid_sampling():
@@ -116,6 +206,55 @@ def test_normal_sampling():
     np.testing.assert_almost_equal(df_test_1["feat_2"].mean(), 20, decimal=0)
     np.testing.assert_almost_equal(df_test_1["feat_1"].std(), 2, decimal=0)
     np.testing.assert_almost_equal(df_test_1["feat_2"].std(), 40, decimal=0)
+
+
+def test_categorical_sampling(nsamples=500, random_state=2, feature_parameters=None):
+    feature_parameters = {
+        "feat_1": {"categories": {"red": 0.5, "blue": 0.5}},
+        "feat_2": {"categories": {1: 0.3, 3: 0.6, 69: 0.1}},
+    }
+    data_generated = categorical_sampling(
+        nsamples=10000, random_state=2, feature_parameters=feature_parameters
+    )
+    for key in feature_parameters:
+        assert key in data_generated.columns
+        for category in feature_parameters[key]["categories"]:
+            obtained_fraction = (
+                data_generated[key].value_counts().loc[[category]].iloc[0] / 10000
+            )
+            expected_probability = feature_parameters[key]["categories"][category]
+            assert obtained_fraction == pytest.approx(expected_probability, 0.05)
+    assert len(data_generated) == 10000
+
+
+def test_mixed_data_sampling():
+    feature_parameters = {
+        "feat_1": {"categories": {1: 0.3, 3: 0.6, 69: 0.1}},
+        "feat_2": {"mean": 20, "sigma": 40},
+    }
+    data_generated = mixed_data_sampling(
+        normal_sampling,
+        nsamples=10000,
+        random_state=2,
+        feature_parameters=feature_parameters,
+    )
+    for key in feature_parameters:
+        assert key in data_generated.columns
+        if "categories" in feature_parameters[key]:
+            for category in feature_parameters[key]["categories"]:
+                obtained_fraction = (
+                    data_generated[key].value_counts().loc[[category]].iloc[0] / 10000
+                )
+                expected_probability = feature_parameters[key]["categories"][category]
+                assert obtained_fraction == pytest.approx(expected_probability, 0.05)
+        else:
+            np.testing.assert_almost_equal(
+                data_generated[key].mean(), feature_parameters[key]["mean"], decimal=0
+            )
+            np.testing.assert_almost_equal(
+                data_generated[key].std(), feature_parameters[key]["sigma"], decimal=0
+            )
+    assert len(data_generated) == 10000
 
 
 def test_labeling():

--- a/tests/test_copies.py
+++ b/tests/test_copies.py
@@ -61,7 +61,7 @@ def test_find_categories():
     }
     df = pd.DataFrame(data, columns=["color", "height", "siblings"])
     df[["color", "siblings"]] = df[["color", "siblings"]].astype("category")
-    category_dict = find_categories(df, add_NaNs=True)
+    category_dict = find_categories(df, add_nans=True)
     expected_category_dict = {
         "color": {"categories": {"red": 0.4, "blue": 0.6}},
         "siblings": {"categories": {1.0: 0.6, 2.0: 0.2, "NaNs": 0.2}},
@@ -109,7 +109,7 @@ def test_mixed_data_features():
     }
     df = pd.DataFrame(data, columns=["color", "height", "siblings"])
     df[["color", "siblings"]] = df[["color", "siblings"]].astype("category")
-    feature_dict = mixed_data_features(df, add_NaNs=True)
+    feature_dict = mixed_data_features(df, add_nans=True)
     expected_feature_dict = {
         "color": {"categories": {"red": 0.4, "blue": 0.6}},
         "height": {"min": 55.8, "max": 80.3, "mean": 67.42, "sigma": 8.94242696},


### PR DESCRIPTION
This PR corresponds to the introduction of the ability to sample and generate **categorical data** when carrying out copies with the **ML Classifier Copy package**.

In summary I have:
* Added the function `find_categories` to conveniently obtain the categorical features dictionary and its probabilities, when a sample of the original data is available.
* Added the function `build_equal_category_dict` to assign equal probabilities to the categories in the feature dictionary, for the cases when the original data is not available.
* Added the `mixed_data_features` function to build the dictionary with the feature parameters when the original data is available and is a mix of numerical and categorical features.
* Added the `categorical_sampling` function that generates categorical data following a discrete distribution with the probabilities specified in the dictionary of feature parameters.
* Added the function `mixed_data_sampling` that generates datasets of mixed numerical and categorical features according to the dictionary of feature parameters.
* Updated the `labeling` function and the `generate_synthetic_data` method of the `ClassifierCopy` class in order to incorporate the ability to deal with categorical features.
* Added/updated the corresponding docstrings for all the functions.
* Added tests for all the new functions.