### PR TITLE
Fix CI failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           docker_layer_caching: true
       - run: apt-get update; apt-get install make -y
       - run: conda env create -f environment.yml
-      - run: . /opt/conda/etc/profile.d/conda.sh && conda activate presc && python setup.py install && make pytest_ci
+      - run: . /opt/conda/etc/profile.d/conda.sh && conda activate presc && python -m pip install . && make pytest_ci
       - persist_to_workspace:
           root: sphinx_docs/build
           paths: html

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ On Windows, these commands should be run from the Anaconda command prompt.
 ```shell
 $ conda env create -f environment.yml
 $ conda activate presc
-$ python setup.py develop
+$ python -m pip install -e .
 $ pre-commit install
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,12 +13,13 @@ dependencies:
   - matplotlib=3.5.1
   - m2r2=0.3.2
   - seaborn=0.11.2
-  - pip=22.0.4
+  - pip=22.3.1
   - plotnine=0.8.0
   - pre-commit=2.17.0
   - pytest=7.0.1
   - pytest-cov=3.0.0
   - pyyaml=6.0
+  - setuptools=65.6.3
   - sphinx=4.4.0
   - twine=3.8.0
   - catboost==1.0.6


### PR DESCRIPTION
Local install of `presc` into the conda env is now failing on a dependency error. This is bypassed by moving to pip for the local install.